### PR TITLE
Update StringBuilder.cls

### DIFF
--- a/force-app/main/default/classes/StringBuilder.cls
+++ b/force-app/main/default/classes/StringBuilder.cls
@@ -4,26 +4,26 @@
 
 public with sharing class StringBuilder {
 
-    private String finalValue;
+    private List<String> buffer = new List<String>();
 
     public StringBuilder(){
-        this.finalValue = '';
     }
 
     public StringBuilder append(String str){
-//        finalValue = String.format('{0}{1}', new List<String>{finalValue, str});
-        finalValue += str;
+        buffer.add(str);
         return this;
     }
 
     public StringBuilder append(Object obj){
-        finalValue += String.valueOf(obj);
+        buffer.add(String.valueOf(obj));
         return this;
     }
 
     public String build(){
-        System.debug(finalValue);
-        return finalValue;
+        return String.join(buffer, '');
     }
 
+    public override String toString() {
+        return build();
+    }
 }


### PR DESCRIPTION
Make use of list of strings as buffer, to perform better utilisation of memory and CPU instruction. Due to strings are immutable objects, every time you append, JVM creates another one, so you get three strings.